### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Environment variables
+.env
 .env.local
 .env.production
 .env.staging


### PR DESCRIPTION
Updated .gitignore to exclude the .env file from version control, preventing sensitive environment variables from being committed.